### PR TITLE
Force encrypted posts to use encrypted layout

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,24 @@ var FileSystem    = require('fs');
 var through       = require('through2');
 var PluginError   = gutil.PluginError;
 
+function forceEncryptedLayout(frontMatter) {
+  var lines = frontMatter.split('\n');
+  var linesWithoutLayout = [];
+
+  lines.forEach(function(line) {
+    var isLayout = line.indexOf('layout:') === 0;
+    if (!isLayout) linesWithoutLayout.push(line);
+  });
+
+  var linesWithLayout = linesWithoutLayout
+    .splice(0, 1)
+    .concat('layout: encrypted')
+    .concat(linesWithoutLayout);
+
+  var frontMatterWithEncryptedLayout = linesWithLayout.join('\n');
+  return frontMatterWithEncryptedLayout;
+}
+
 function encrypt(password) {
   return through.obj(function(file, encoding, callback) {
     if (file.isNull() || file.isDirectory()) {
@@ -27,12 +45,13 @@ function encrypt(password) {
 
     if (file.isBuffer()) {
       var chunks = String(file.contents).split('---');
+      var frontMatter = forceEncryptedLayout(chunks[1]);
 
       var encrypted = cryptojs.AES.encrypt(marked(chunks[2]), password);
       var hmac = cryptojs.HmacSHA256(encrypted.toString(), cryptojs.SHA256(password).toString()).toString();
       var encryptedMessage = 'encrypted: ' + hmac + encrypted;
 
-      var result = [ '---', chunks[1], '\n', encryptedMessage, '\n', '---' ]
+      var result = [ '---', frontMatter, '\n', encryptedMessage, '\n', '---' ]
 
       file.contents = new Buffer(result.join(''));
       this.push(file);


### PR DESCRIPTION
This function adds an extra security check in case somebody would create a new post inside the `protected` folder but forgot to use the correct layout name.