### PR TITLE
Add minimum length check for password

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,8 @@ var FileSystem    = require('fs');
 var through       = require('through2');
 var PluginError   = gutil.PluginError;
 
+var password = 'password';
+
 function encrypt(password) {
   return through.obj(function(file, encoding, callback) {
     if (file.isNull() || file.isDirectory()) {
@@ -41,9 +43,28 @@ function encrypt(password) {
   });
 }
 
-gulp.task('encrypt', () => {
+/*
+ * Check if password is at least 12 characters long for a good measure.
+ *
+ * Source: https://www.betterbuys.com/estimating-password-cracking-times/
+ */
+gulp.task('check-password', function() {
+  if (!password || password.length < 12) {
+    var message = [
+      'Please use a password at least 12 characters long.',
+      'Otherwise, an attacker might download your files and brute force the password locally.',
+      'See https://www.betterbuys.com/estimating-password-cracking-times/ for more info.'
+    ];
+    this.emit('error', new PluginError({
+      plugin: 'Encrypt',
+      message: message.join('\n    ')
+    }));
+  }
+});
+
+gulp.task('encrypt', ['check-password'], () => {
   return gulp.src('_protected/*.*')
-    .pipe(encrypt('password'))
+    .pipe(encrypt(password))
     .pipe(gulp.dest('_posts'));
 });
 


### PR DESCRIPTION
Force the user to select a password that is at least 12 characters long to decrease the chance of somebody downloading their files locally and brute forcing their way in.