### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,15 +95,16 @@ gulp.task('firewall:encrypt', () => {
 });
 
 gulp.task('firewall:watch', () => {
-  gulp.watch('_protected/*.*', ['encrypt']);
+  gulp.watch('_protected/*.*', gulp.series('firewall:encrypt'));
 });
 
-gulp.task('firewall', ['firewall:encrypt', 'firewall:watch'], () => {});
+gulp.task('firewall', gulp.series('firewall:encrypt', 'firewall:watch',() => {}));
+
 
 /*
   END FIREWALL TASKS
 */
 
-gulp.task('default', ['firewall'], () => {
+gulp.task('default', gulp.series('firewall', () => {
   // your tasks here
-});
+}));


### PR DESCRIPTION
Since the last gulp update (from 3.x to 4.x), some extra requirements has been added to the gulpfile.js script. The old way to program tasks as performed in serial or in parallel is depreciated and will cause errors. This update has fixed the issue and is partly adapted to the latest gulp version with minor issues. The depreciated module gulp-util isn't replaced, but it won't cause any problems when using the script.